### PR TITLE
Create GoLand dirs with user ownership

### DIFF
--- a/goland
+++ b/goland
@@ -10,7 +10,7 @@ then
 fi
 
 function create_dir() {
-  mkdir ${1}
+  mkdir -p ${1}
   sudo chown ${USER}:${USER} ${1}
 }
 

--- a/goland
+++ b/goland
@@ -9,6 +9,18 @@ then
   exit 1
 fi
 
+function create_dir() {
+  if [ ! -d "${1}" ]; then
+    mkdir ${1}
+    sudo chown ${USER}:${USER} ${1}
+  fi
+}
+
+function create_dirs() {
+  create_dir ~/.GoLand
+  create_dir ~/.GoLand.java
+}
+
 function setup_env_vars() {
   PORT=$(ps -ef | grep "Xquartz :\d" | grep -v xinit | awk '{ print $9; }')
   display="--env DISPLAY=$(hostname)${PORT}"
@@ -44,6 +56,7 @@ function run() {
              ${GOLAND}
 }
 
+create_dirs
 setup_xquartz
 setup_env_vars
 pull_latest

--- a/goland
+++ b/goland
@@ -10,10 +10,8 @@ then
 fi
 
 function create_dir() {
-  if [ ! -d "${1}" ]; then
-    mkdir ${1}
-    sudo chown ${USER}:${USER} ${1}
-  fi
+  mkdir ${1}
+  sudo chown ${USER}:${USER} ${1}
 }
 
 function create_dirs() {


### PR DESCRIPTION
If the dirs don't exist, docker creates them with root as owner which prevents GoLand from launching