### PR TITLE
fix: ensures all mounted directories exist before mounting them

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -7,6 +7,7 @@ SCRIPT_HOME="$(dirname $BASH_SOURCE | sed 's:^\.$:'"$PWD"':g')"
 [ ! -z "$CLOUD_SHELL" ] && ENV=cloud || ENV=mac
 declare -a env_files=(".bash_history" ".boto" ".gitconfig")
 source ./env/env.sh $ENV
+declare -a mounted_directories=("$WORKSPACE" "$GO_WORKSPACE" "${MOUNT}/.cache" "${MOUNT}/.config" "${MOUNT}/.docker" "${MOUNT}/.gnupg" "${MOUNT}/.groovy" "${MOUNT}/.gsutil" "${MOUNT}/.helm" "${MOUNT}/.jx" "${MOUNT}/.m2" "${MOUNT}/.terraform" "${MOUNT}/.terraform.d")
 
 function setup_workspace(){
   if [[ ! -d $GO_WORKSPACE ]]
@@ -57,6 +58,12 @@ function setup_environment(){
       echo "${MOUNT}/${file} file doesn't exist, creating..."
       touch ${MOUNT}/${file}
     fi
+  done
+
+  echo "initializing mounted directories"
+  for dir in "${mounted_directories[@]}"
+  do
+    mkdir -p ${dir}
   done
 }
 


### PR DESCRIPTION
That ensures that mounted directories are created by current user before launching the container to prevent them from being created by Docker itself with root:root permissions on the host.

Should fix #78 